### PR TITLE
5 create helm charts for regtech mail api and mailpit

### DIFF
--- a/mailpit_chart/Chart.yaml
+++ b/mailpit_chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: mailpit
+description: A simple Helm Chart for mailpit
+
+type: application
+
+version: 0.1.0

--- a/mailpit_chart/templates/deployment.yaml
+++ b/mailpit_chart/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailpit
+  namespace: regtech
+  labels:
+    mailing.app: mailpit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      mailing.app: mailpit
+  template:
+    metadata:
+      labels:
+        mailing.app: mailpit
+    spec:
+      serviceAccountName: secrets-csi-sa
+      volumes:
+      - name: mailing-api-secrets
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: regtech-provider
+      containers:
+        - name: mailpit
+          image: "axllent/mailpit"
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: mailing-api-secrets
+            mountPath: "/mnt/secrets-store"
+            readOnly: true
+          env:
+            - name: MP_SMTP_AUTH_ACCEPT_ANY
+              value: "0"
+            - name: MP_SMTP_AUTH_ALLOW_INSECURE
+              value: "1"
+            - name: MP_SMTP_AUTH
+              value: "$(SMTP_USERNAME):$(SMTP_PASSWORD)"
+            - name: SMTP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mailing-api-secrets
+                  key: SMTP_USERNAME
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mailing-api-secrets
+                  key: SMTP_PASSWORD
+          ports:
+            - containerPort: 8025
+            - containerPort: 1025
+          resources: {}

--- a/mailpit_chart/templates/deployment.yaml
+++ b/mailpit_chart/templates/deployment.yaml
@@ -36,8 +36,6 @@ spec:
               value: "0"
             - name: MP_SMTP_AUTH_ALLOW_INSECURE
               value: "1"
-            - name: MP_SMTP_AUTH
-              value: "$(SMTP_USERNAME):$(SMTP_PASSWORD)"
             - name: SMTP_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -48,6 +46,8 @@ spec:
                 secretKeyRef:
                   name: mailing-api-secrets
                   key: SMTP_PASSWORD
+            - name: MP_SMTP_AUTH
+              value: "$(SMTP_USERNAME):$(SMTP_PASSWORD)"
           ports:
             - containerPort: 8025
             - containerPort: 1025

--- a/mailpit_chart/templates/mapping.yml
+++ b/mailpit_chart/templates/mapping.yml
@@ -1,0 +1,13 @@
+{{- if .Values.mapping.enabled }}
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: mailpit
+  namespace: regtech
+spec:
+  ambassador_id:
+    --apiVersion-v3alpha1-only--default
+  host: {{ .Values.mapping.host }}
+  prefix: {{ .Values.mapping.prefix }}
+  service: mailpit
+{{- end }}

--- a/mailpit_chart/templates/service.yaml
+++ b/mailpit_chart/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailpit
+  namespace: regtech
+  labels:
+    mailing.app: mailpit
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8025
+      protocol: TCP
+      name: http
+    - port: 1025
+      targetPort: 1025
+      protocol: TCP
+      name: smpt-port
+  selector:
+    mailing.app: mailpit

--- a/mailpit_chart/values.yaml
+++ b/mailpit_chart/values.yaml
@@ -1,0 +1,5 @@
+mapping:
+  enabled: true
+  host: mailpit-devpub-cd-eval.dev-public.aws.cfpb.gov
+  prefix: /
+

--- a/mailpit_chart/values.yaml
+++ b/mailpit_chart/values.yaml
@@ -1,5 +1,5 @@
 mapping:
   enabled: true
-  host: mailpit-devpub-cd-eval.dev-public.aws.cfpb.gov
+  host: mailpit-eks.dev-public.aws.cfpb.gov
   prefix: /
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -43,8 +43,8 @@ match settings.email_mailer:
         mailer = SmtpMailer(
             settings.smtp_host,  # type: ignore
             settings.smtp_port,
-            settings.smtp_username,  # type: ignore
-            settings.smtp_password,  # type: ignore
+            settings.smtp_username.get_secret_value(),  # type: ignore
+            settings.smtp_password.get_secret_value(),  # type: ignore
             settings.smtp_use_tls,
         )
     case EmailMailerType.MOCK:


### PR DESCRIPTION
Closes #5 

See PR #44 in the EKS repo for Helm values files for the mailing-api.  These use the standard Helm templates in the sbl-deployment repo.

Hardcoded most of this since I feel like there isn't a ton of need for flexibility here but will gladly helmatize it more if y'all would prefer.

