### PR TITLE
18 implement template for sf emails

### DIFF
--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -62,16 +62,9 @@ def read_root(request: Request):
 @app.post("/send")
 @requires("authenticated")
 async def send_email(request: Request):
-<<<<<<< HEAD
     sender_addr = request.user.email
     sender_name = request.user.name
     subject = f"SBL Portal User Request for {sender_name if sender_name else request.user.username}"
-=======
-    headers = request.headers
-    subject = headers["X-Mail-Subject"]
-    sender_addr = request.user.email
-    sender_name = request.user.name
->>>>>>> main
 
     sender = f"{sender_name} <{sender_addr}>" if sender_name else sender_addr
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -9,7 +9,6 @@ from regtech_mail_api.settings import EmailApiSettings, EmailMailerType, kc_sett
 from starlette.authentication import requires
 from starlette.middleware.authentication import AuthenticationMiddleware
 
-from regtech_api_commons.models.auth import AuthenticatedUser
 from regtech_api_commons.oauth2.oauth2_backend import BearerTokenAuthBackend
 from regtech_api_commons.oauth2.oauth2_admin import OAuth2Admin
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -80,7 +80,7 @@ async def send_email(request: Request):
     sender_addr = request.user.email
     sender_name = request.user.name
 
-    sender = (f"{sender_name} <{sender_addr}>" if sender_addr else sender_name).strip()
+    sender = f"{sender_name} <{sender_addr}>" if sender_name else sender_addr
 
     form_data = await request.form()
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -65,7 +65,7 @@ async def send_email(request: Request):
     sender_addr = request.user.email
     sender_name = request.user.name
     type = request.headers["case-type"]
-    subject = f"[DEV BETA] SBL Portal User Request for {type}" + (
+    subject = f"[DEV BETA] SBL User Request for {type}" + (
         f" by {sender_name}" if sender_name else ""
     )
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -28,7 +28,7 @@ app.add_middleware(
     allow_origins=[
         "*"
     ],  # thinking this should be derived from an env var from docker-compose or helm values
-    allow_methods=["GET", "POST"],
+    allow_methods=["*"],
     allow_headers=["authorization"],
 )
 
@@ -75,17 +75,17 @@ async def get_debug_info(request: Request):
 @app.post("/send")
 @requires("authenticated")
 async def send_email(request: Request):
-    headers = request.headers
-    subject = headers["X-Mail-Subject"]
     sender_addr = request.user.email
     sender_name = request.user.name
+    subject = f"SBL Portal User Request for {sender_name if sender_name else request.user.username}"
 
     sender = f"{sender_name} <{sender_addr}>" if sender_name else sender_addr
 
     form_data = await request.form()
 
     body_lines = [f"{k}: {v}" for k, v in form_data.items()]
-    email_body = "\n".join(body_lines)
+    email_body = f"Contact Email: {sender_addr}\n\n"
+    email_body += "\n".join(body_lines)
 
     email = Email(subject, email_body, settings.from_addr, sender, to={settings.to})
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -9,6 +9,7 @@ from regtech_mail_api.settings import EmailApiSettings, EmailMailerType, kc_sett
 from starlette.authentication import requires
 from starlette.middleware.authentication import AuthenticationMiddleware
 
+from regtech_api_commons.models.auth import AuthenticatedUser
 from regtech_api_commons.oauth2.oauth2_backend import BearerTokenAuthBackend
 from regtech_api_commons.oauth2.oauth2_admin import OAuth2Admin
 
@@ -77,10 +78,10 @@ async def get_debug_info(request: Request):
 async def send_email(request: Request):
     headers = request.headers
     subject = headers["X-Mail-Subject"]
-    sender_addr = headers["X-Mail-Sender-Address"]
-    sender_name = headers["X-Mail-Sender-Name"]
+    sender_addr = request.user.email
+    sender_name = request.user.name
 
-    sender = f"{sender_name} <{sender_addr}>" if sender_addr else sender_name
+    sender = (f"{sender_name} <{sender_addr}>" if sender_addr else sender_name).strip()
 
     form_data = await request.form()
 

--- a/regtech_mail_api/api.py
+++ b/regtech_mail_api/api.py
@@ -43,8 +43,8 @@ match settings.email_mailer:
         mailer = SmtpMailer(
             settings.smtp_host,  # type: ignore
             settings.smtp_port,
-            settings.smtp_username,  # type: ignore
-            settings.smtp_password,  # type: ignore
+            settings.smtp_username.get_secret_value(),  # type: ignore
+            settings.smtp_password.get_secret_value(),  # type: ignore
             settings.smtp_use_tls,
         )
     case EmailMailerType.MOCK:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -26,6 +26,7 @@ def auth_mock(mocker: MockerFixture) -> Mock:
 @pytest.fixture
 def authed_user_mock(auth_mock: Mock) -> Mock:
     claims = {
+        "name": "Test User",
         "preferred_username": "test_user",
         "email": "test@cfpb.gov",
     }
@@ -78,22 +79,3 @@ class TestEmailApiAuthentication:
         client = TestClient(app_fixture)
         res = client.get("/")
         assert res.status_code == 200
-
-        client = TestClient(app_fixture)
-        res = client.post(
-            "/send",
-            json=email_json,
-            headers={
-                "X-Mail-Subject": "Institution Profile Change",
-                "X-Mail-Sender-Address": "jane.doe@some.org",
-                "X-Mail-Sender-Name": "Jane Doe",
-            },
-            data={
-                "lei": "1234567890ABCDEFGHIJ",
-                "institution_name_1": "Fintech 1",
-                "tin_1": "12-3456789",
-                "rssd_1": "1234567",
-            },
-        )
-        assert res.status_code == 200
-        assert res.json() == email_json

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -27,10 +27,7 @@ def auth_mock(mocker: MockerFixture) -> Mock:
 def user_no_profile_mock(auth_mock: Mock) -> Mock:
     claims = {
         "email": "test@cfpb.gov",
-<<<<<<< HEAD
         "preferred_username": "testuser",
-=======
->>>>>>> main
     }
     auth_mock.return_value = (
         AuthCredentials(["authenticated"]),
@@ -43,10 +40,7 @@ def user_no_profile_mock(auth_mock: Mock) -> Mock:
 def full_user_mock(auth_mock: Mock) -> Mock:
     claims = {
         "name": "Test User",
-<<<<<<< HEAD
         "preferred_username": "testuser",
-=======
->>>>>>> main
         "email": "test@cfpb.gov",
     }
     auth_mock.return_value = (
@@ -63,13 +57,8 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-<<<<<<< HEAD
                 "subject": "SBL Portal User Request for testuser",
                 "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
-=======
-                "subject": "Institution Profile Change",
-                "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
->>>>>>> main
                 "from_addr": "test@cfpb.gov",
                 "sender": "test@cfpb.gov",
                 "to": ["cases@localhost.localdomain"],
@@ -99,13 +88,8 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-<<<<<<< HEAD
                 "subject": "SBL Portal User Request for Test User",
                 "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
-=======
-                "subject": "Institution Profile Change",
-                "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
->>>>>>> main
                 "from_addr": "test@cfpb.gov",
                 "sender": "Test User <test@cfpb.gov>",
                 "to": ["cases@localhost.localdomain"],

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -57,7 +57,7 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "[DEV BETA] SBL Portal User Request for Institution Profile Change",
+                "subject": "[DEV BETA] SBL User Request for Institution Profile Change",
                 "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "sender": "test@cfpb.gov",
@@ -88,7 +88,7 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "[DEV BETA] SBL Portal User Request for Institution Profile Change by Test User",
+                "subject": "[DEV BETA] SBL User Request for Institution Profile Change by Test User",
                 "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "sender": "Test User <test@cfpb.gov>",

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from unittest.mock import Mock
 
 from regtech_api_commons.models.auth import AuthenticatedUser
-from starlette.authentication import AuthCredentials, UnauthenticatedUser
+from starlette.authentication import AuthCredentials
 
 
 @pytest.fixture
@@ -21,6 +21,7 @@ def auth_mock(mocker: MockerFixture) -> Mock:
     return mocker.patch(
         "regtech_api_commons.oauth2.oauth2_backend.BearerTokenAuthBackend.authenticate"
     )
+
 
 @pytest.fixture
 def user_no_profile_mock(auth_mock: Mock) -> Mock:
@@ -63,7 +64,7 @@ class TestEmailApiSend:
                 "bcc": None,
             }
         }
-        
+
         client = TestClient(app_fixture)
         res = client.post(
             "/send",
@@ -94,7 +95,7 @@ class TestEmailApiSend:
                 "bcc": None,
             }
         }
-        
+
         client = TestClient(app_fixture)
         res = client.post(
             "/send",

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -58,7 +58,7 @@ class TestEmailApiSend:
                 "subject": "Institution Profile Change",
                 "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
-                "sender": "<test@cfpb.gov>",
+                "sender": "test@cfpb.gov",
                 "to": ["cases@localhost.localdomain"],
                 "cc": None,
                 "bcc": None,

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -57,7 +57,7 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "SBL Portal User Request for testuser",
+                "subject": "[DEV BETA] SBL Portal User Request for Institution Profile Change",
                 "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "sender": "test@cfpb.gov",
@@ -71,7 +71,7 @@ class TestEmailApiSend:
         res = client.post(
             "/send",
             headers={
-                "X-Mail-Subject": "Institution Profile Change",
+                "case-type": "Institution Profile Change",
             },
             data={
                 "lei": "1234567890ABCDEFGHIJ",
@@ -88,7 +88,7 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "SBL Portal User Request for Test User",
+                "subject": "[DEV BETA] SBL Portal User Request for Institution Profile Change by Test User",
                 "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "sender": "Test User <test@cfpb.gov>",
@@ -102,7 +102,7 @@ class TestEmailApiSend:
         res = client.post(
             "/send",
             headers={
-                "X-Mail-Subject": "Institution Profile Change",
+                "case-type": "Institution Profile Change",
             },
             data={
                 "lei": "1234567890ABCDEFGHIJ",

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -27,6 +27,7 @@ def auth_mock(mocker: MockerFixture) -> Mock:
 def user_no_profile_mock(auth_mock: Mock) -> Mock:
     claims = {
         "email": "test@cfpb.gov",
+        "preferred_username": "testuser",
     }
     auth_mock.return_value = (
         AuthCredentials(["authenticated"]),
@@ -39,6 +40,7 @@ def user_no_profile_mock(auth_mock: Mock) -> Mock:
 def full_user_mock(auth_mock: Mock) -> Mock:
     claims = {
         "name": "Test User",
+        "preferred_username": "testuser",
         "email": "test@cfpb.gov",
     }
     auth_mock.return_value = (
@@ -55,8 +57,8 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "Institution Profile Change",
-                "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
+                "subject": "SBL Portal User Request for testuser",
+                "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "sender": "test@cfpb.gov",
                 "to": ["cases@localhost.localdomain"],
@@ -86,8 +88,8 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "Institution Profile Change",
-                "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
+                "subject": "SBL Portal User Request for Test User",
+                "body": "Contact Email: test@cfpb.gov\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "sender": "Test User <test@cfpb.gov>",
                 "to": ["cases@localhost.localdomain"],

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -1,0 +1,112 @@
+import pytest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+from unittest.mock import Mock
+
+from regtech_api_commons.models.auth import AuthenticatedUser
+from starlette.authentication import AuthCredentials, UnauthenticatedUser
+
+
+@pytest.fixture
+def app_fixture(mocker: MockerFixture) -> FastAPI:
+    from api import app
+
+    return app
+
+
+@pytest.fixture
+def auth_mock(mocker: MockerFixture) -> Mock:
+    return mocker.patch(
+        "regtech_api_commons.oauth2.oauth2_backend.BearerTokenAuthBackend.authenticate"
+    )
+
+@pytest.fixture
+def user_no_profile_mock(auth_mock: Mock) -> Mock:
+    claims = {
+        "email": "test@cfpb.gov",
+    }
+    auth_mock.return_value = (
+        AuthCredentials(["authenticated"]),
+        AuthenticatedUser.from_claim(claims),
+    )
+    return auth_mock
+
+
+@pytest.fixture
+def full_user_mock(auth_mock: Mock) -> Mock:
+    claims = {
+        "name": "Test User",
+        "email": "test@cfpb.gov",
+    }
+    auth_mock.return_value = (
+        AuthCredentials(["authenticated"]),
+        AuthenticatedUser.from_claim(claims),
+    )
+    return auth_mock
+
+
+class TestEmailApiSend:
+
+    def test_send_no_profile(
+        self, mocker: MockerFixture, app_fixture: FastAPI, user_no_profile_mock: Mock
+    ):
+        email_json = {
+            "email": {
+                "subject": "Institution Profile Change",
+                "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
+                "from_addr": "test@cfpb.gov",
+                "sender": "<test@cfpb.gov>",
+                "to": ["cases@localhost.localdomain"],
+                "cc": None,
+                "bcc": None,
+            }
+        }
+        
+        client = TestClient(app_fixture)
+        res = client.post(
+            "/send",
+            headers={
+                "X-Mail-Subject": "Institution Profile Change",
+            },
+            data={
+                "lei": "1234567890ABCDEFGHIJ",
+                "institution_name_1": "Fintech 1",
+                "tin_1": "12-3456789",
+                "rssd_1": "1234567",
+            },
+        )
+        assert res.status_code == 200
+        assert res.json() == email_json
+
+    def test_send(
+        self, mocker: MockerFixture, app_fixture: FastAPI, full_user_mock: Mock
+    ):
+        email_json = {
+            "email": {
+                "subject": "Institution Profile Change",
+                "body": "lei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
+                "from_addr": "test@cfpb.gov",
+                "sender": "Test User <test@cfpb.gov>",
+                "to": ["cases@localhost.localdomain"],
+                "cc": None,
+                "bcc": None,
+            }
+        }
+        
+        client = TestClient(app_fixture)
+        res = client.post(
+            "/send",
+            headers={
+                "X-Mail-Subject": "Institution Profile Change",
+            },
+            data={
+                "lei": "1234567890ABCDEFGHIJ",
+                "institution_name_1": "Fintech 1",
+                "tin_1": "12-3456789",
+                "rssd_1": "1234567",
+            },
+        )
+        assert res.status_code == 200
+        assert res.json() == email_json


### PR DESCRIPTION
Closes #18 

Current template format used, just to get the ball rolling.  

Merged in #16 since it needed the same objs.  So this can either replace that or I'll have to play the merge conflict game.  But wanted to get this out there for the front end to use and for eyes on it.

Bill's tested with the frontend talking to the cluster and everything looks groovy.  Results from me curling an email with Bill as the configed TO were:
![image](https://github.com/cfpb/regtech-mail-api/assets/41971533/8a934cd1-2a59-4ac5-ae77-277333a616f2)