### PR TITLE
feat: run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ COPY src/ ./
 
 EXPOSE 8765
 
+USER sbl
+
 CMD ["uvicorn", "regtech_mail_api.api:app", "--host", "0.0.0.0", "--port", "8765", "--log-config", "log-config.yml"]


### PR DESCRIPTION
Runs the mailing-api container as unprivileged `sbl` user.

Validated the container is able to function properly with the change.