### PR TITLE
Updated code to set header on email subject based on desired logic

### DIFF
--- a/src/regtech_mail_api/api.py
+++ b/src/regtech_mail_api/api.py
@@ -65,7 +65,15 @@ async def send_email(request: Request):
     sender_addr = request.user.email
     sender_name = request.user.name if request.user.name else ""
     type = request.headers["case-type"]
-    subject = f"[DEV BETA] SBL User Request for {type}"
+
+    header = "[BETA]"
+    if "cfpb" in sender_addr:
+        header = "[CFPB BETA]"
+    if settings.environment:
+        if settings.environment == "DEV":
+            header = "[DEV BETA]"
+
+    subject = f"{header} SBL User Request for {type}"
 
     form_data = await request.form()
 

--- a/src/regtech_mail_api/api.py
+++ b/src/regtech_mail_api/api.py
@@ -67,7 +67,7 @@ async def send_email(request: Request):
     type = request.headers["case-type"]
 
     header = "[BETA]"
-    if "cfpb" in sender_addr:
+    if "cfpb" in sender_addr.lower().split("@")[-1]:
         header = "[CFPB BETA]"
     if settings.environment:
         header = f"[{settings.environment}]"

--- a/src/regtech_mail_api/api.py
+++ b/src/regtech_mail_api/api.py
@@ -70,8 +70,7 @@ async def send_email(request: Request):
     if "cfpb" in sender_addr:
         header = "[CFPB BETA]"
     if settings.environment:
-        if settings.environment == "DEV":
-            header = "[DEV BETA]"
+        header = f"[{settings.environment}]"
 
     subject = f"{header} SBL User Request for {type}"
 

--- a/src/regtech_mail_api/settings.py
+++ b/src/regtech_mail_api/settings.py
@@ -11,6 +11,7 @@ class EmailMailerType(str, Enum):
 
 
 class EmailApiSettings(BaseSettings):
+    environment: str = ""
     email_mailer: EmailMailerType = EmailMailerType.SMTP
     smtp_host: str | None = None
     smtp_port: int = 0

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -57,7 +57,7 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "[DEV BETA] SBL User Request for Institution Profile Change",
+                "subject": "[CFPB BETA] SBL User Request for Institution Profile Change",
                 "body": "Contact Email: test@cfpb.gov\nContact Name: \n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "to": ["cases@localhost.localdomain"],
@@ -87,7 +87,7 @@ class TestEmailApiSend:
     ):
         email_json = {
             "email": {
-                "subject": "[DEV BETA] SBL User Request for Institution Profile Change",
+                "subject": "[CFPB BETA] SBL User Request for Institution Profile Change",
                 "body": "Contact Email: test@cfpb.gov\nContact Name: Test User\n\nlei: 1234567890ABCDEFGHIJ\ninstitution_name_1: Fintech 1\ntin_1: 12-3456789\nrssd_1: 1234567",
                 "from_addr": "test@cfpb.gov",
                 "to": ["cases@localhost.localdomain"],


### PR DESCRIPTION
Closes #38 

Tested locally in docker by setting ENVIRONMENT: DEV in the docker-compose env variables for the mailing-api, which sent to mailpint an email with `"subject": "[DEV BETA] SBL User Request for Institution Profile Change"`

Then removed the ENVIRONMENT variable and changed the keycloak user to have both @cfpg.gov and @new-cfpb.gov email domains, both results ended in an email with `"subject": "[CFPB BETA] SBL User Request for Institution Profile Change"`

Changed account to have an email domain of "citibank.com" and had an email sent with `"subject": "[BETA] SBL User Request for Institution Profile Change"`

