### PR TITLE
50 fix confirmation email for beta language

### DIFF
--- a/src/regtech_mail_api/internal.py
+++ b/src/regtech_mail_api/internal.py
@@ -8,7 +8,7 @@ from regtech_api_commons.api.router_wrapper import Router
 
 from regtech_mail_api.settings import EmailApiSettings
 from regtech_mail_api.models import Email
-from regtech_mail_api.mailer import create_mailer, get_header
+from regtech_mail_api.mailer import create_mailer
 
 settings = EmailApiSettings()
 
@@ -24,10 +24,16 @@ class ConfirmationRequest(BaseModel):
     confirmation_id: str
 
 
-body_template = """
+prod_body_template = """
     Congratulations! This email confirms that the filing submitted by {signer_name} on {formatted_date} was successful. The confirmation number is {confirmation_id}.
 
     To make any changes to the filing, please return to the Small Business Lending Data Filing Platform and follow the provided instructions. If you have any questions or need additional support, email our support staff at sblhelp@cfpb.gov.
+"""
+
+beta_body_template = """
+    Congratulations! This email confirms that the filing submitted by {signer_name} on {formatted_date} was successful. The confirmation number is {confirmation_id}.
+
+    The beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or upload a new file to continue testing.
 """
 
 
@@ -39,6 +45,9 @@ async def send_email(request: Request, confirmation_request: ConfirmationRequest
         ZoneInfo("America/New_York")
     )
     formatted_date = timestamp_est.strftime("%B %d, %Y at %-I:%M %p %Z")
+    body_template = (
+        prod_body_template if settings.environment == "PROD" else beta_body_template
+    )
     body_text = dedent(
         body_template.format(
             signer_name=confirmation_request.signer_name,
@@ -47,9 +56,14 @@ async def send_email(request: Request, confirmation_request: ConfirmationRequest
         )
     )
 
-    to_list = [confirmation_request.contact_email, confirmation_request.signer_email]
+    to_list = (
+        [confirmation_request.contact_email, confirmation_request.signer_email]
+        if settings.environment == "PROD"
+        else [confirmation_request.signer_email]
+    )
+    header = "" if settings.environment == "PROD" else "[BETA] "
     email = Email(
-        f"{get_header(confirmation_request.signer_email)} Small Business Lending Data Filing Confirmation",
+        f"{header}Small Business Lending Data Filing Confirmation",
         body_text,
         settings.from_addr,
         to=to_list,

--- a/src/regtech_mail_api/internal.py
+++ b/src/regtech_mail_api/internal.py
@@ -33,7 +33,7 @@ prod_body_template = """
 beta_body_template = """
     Congratulations! This email confirms that the filing submitted by {signer_name} on {formatted_date} was successful. The confirmation number is {confirmation_id}.
 
-    The beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or upload a new file to continue testing.
+    The beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.
 """
 
 

--- a/src/regtech_mail_api/internal.py
+++ b/src/regtech_mail_api/internal.py
@@ -14,6 +14,16 @@ settings = EmailApiSettings()
 
 router = Router()
 
+custom_months = {
+    "January": "Jan.",
+    "February": "Feb.",
+    "August": "Aug.",
+    "September": "Sept.",
+    "October": "Oct.",
+    "November": "Nov.",
+    "December": "Dec.",
+}
+
 
 class ConfirmationRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -44,7 +54,12 @@ async def send_email(request: Request, confirmation_request: ConfirmationRequest
     timestamp_est = confirmation_request.timestamp.astimezone(
         ZoneInfo("America/New_York")
     )
-    formatted_date = timestamp_est.strftime("%B %d, %Y at %-I:%M %p %Z")
+    full_month = timestamp_est.strftime("%B")
+    formatted_month = custom_months.get(full_month, full_month)
+    am_pm = "a.m." if timestamp_est.strftime("%p") == "AM" else "p.m."
+    formatted_date = (
+        f"{formatted_month} {timestamp_est.strftime("%d, %Y at %-I:%M")} {am_pm} EST"
+    )
     body_template = (
         prod_body_template if settings.environment == "PROD" else beta_body_template
     )

--- a/src/regtech_mail_api/mailer.py
+++ b/src/regtech_mail_api/mailer.py
@@ -75,4 +75,6 @@ def get_header(email):
         header = "[CFPB BETA]"
     if settings.environment:
         header = f"[{settings.environment}]"
+        if settings.environment == "PROD":
+            header = ""
     return header

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -9,6 +9,8 @@ from unittest.mock import Mock, patch
 from regtech_api_commons.models.auth import AuthenticatedUser
 from starlette.authentication import AuthCredentials
 
+from datetime import datetime
+
 
 @pytest.fixture
 def app_fixture(mocker: MockerFixture) -> FastAPI:
@@ -113,6 +115,60 @@ class TestEmailApiSend:
         assert res.status_code == 200
         assert res.json() == email_json
 
+    def test_email_dates(
+        self, mocker: MockerFixture, app_fixture: FastAPI, full_user_mock: Mock
+    ):
+        client = TestClient(app_fixture)
+        res = client.post(
+            "/internal/confirmation/send",
+            data=json.dumps(
+                {
+                    "confirmation_id": "test",
+                    "signer_email": "test@cfpb.gov",
+                    "signer_name": "Test User",
+                    "contact_email": "test_contact@cfpb.gov",
+                    "timestamp": datetime(2024, 3, 15, 8, 10).timestamp() * 1000,
+                }
+            ),
+        )
+
+        expected_email = {
+            "subject": "[BETA] Small Business Lending Data Filing Confirmation",
+            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on March 15, 2024 at 10:10 a.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
+            "from_addr": "test@cfpb.gov",
+            "to": ["test@cfpb.gov"],
+            "cc": None,
+            "bcc": None,
+        }
+
+        assert res.status_code == 200
+        assert res.json()["email"] == expected_email
+
+        res = client.post(
+            "/internal/confirmation/send",
+            data=json.dumps(
+                {
+                    "confirmation_id": "test",
+                    "signer_email": "test@cfpb.gov",
+                    "signer_name": "Test User",
+                    "contact_email": "test_contact@cfpb.gov",
+                    "timestamp": datetime(2024, 9, 15, 13, 10).timestamp() * 1000,
+                }
+            ),
+        )
+
+        expected_email = {
+            "subject": "[BETA] Small Business Lending Data Filing Confirmation",
+            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on Sept. 15, 2024 at 3:10 p.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
+            "from_addr": "test@cfpb.gov",
+            "to": ["test@cfpb.gov"],
+            "cc": None,
+            "bcc": None,
+        }
+
+        assert res.status_code == 200
+        assert res.json()["email"] == expected_email
+
     def test_confirmation_send(
         self, mocker: MockerFixture, app_fixture: FastAPI, full_user_mock: Mock
     ):
@@ -132,7 +188,7 @@ class TestEmailApiSend:
 
         expected_email = {
             "subject": "[BETA] Small Business Lending Data Filing Confirmation",
-            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on November 20, 2024 at 1:51 PM EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
+            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on Nov. 20, 2024 at 1:51 p.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
             "from_addr": "test@cfpb.gov",
             "to": ["test@cfpb.gov"],
             "cc": None,
@@ -149,7 +205,7 @@ class TestEmailApiSend:
             mock_settings.from_addr = "test@cfpb.gov"
             expected_email = {
                 "subject": "Small Business Lending Data Filing Confirmation",
-                "body": "\nCongratulations! This email confirms that the filing submitted by Test User on November 20, 2024 at 1:51 PM EST was successful. The confirmation number is test.\n\nTo make any changes to the filing, please return to the Small Business Lending Data Filing Platform and follow the provided instructions. If you have any questions or need additional support, email our support staff at sblhelp@cfpb.gov.\n",
+                "body": "\nCongratulations! This email confirms that the filing submitted by Test User on Nov. 20, 2024 at 1:51 p.m. EST was successful. The confirmation number is test.\n\nTo make any changes to the filing, please return to the Small Business Lending Data Filing Platform and follow the provided instructions. If you have any questions or need additional support, email our support staff at sblhelp@cfpb.gov.\n",
                 "from_addr": "test@cfpb.gov",
                 "to": ["test_contact@cfpb.gov", "test@cfpb.gov"],
                 "cc": None,

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -132,7 +132,7 @@ class TestEmailApiSend:
 
         expected_email = {
             "subject": "[BETA] Small Business Lending Data Filing Confirmation",
-            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on November 20, 2024 at 1:51 PM EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or upload a new file to continue testing.\n",
+            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on November 20, 2024 at 1:51 PM EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
             "from_addr": "test@cfpb.gov",
             "to": ["test@cfpb.gov"],
             "cc": None,

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 from regtech_api_commons.models.auth import AuthenticatedUser
 from starlette.authentication import AuthCredentials
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 @pytest.fixture
@@ -127,14 +127,17 @@ class TestEmailApiSend:
                     "signer_email": "test@cfpb.gov",
                     "signer_name": "Test User",
                     "contact_email": "test_contact@cfpb.gov",
-                    "timestamp": datetime(2024, 3, 15, 8, 10).timestamp() * 1000,
+                    "timestamp": datetime(
+                        2024, 3, 15, 10, 10, tzinfo=timezone.utc
+                    ).timestamp()
+                    * 1000,
                 }
             ),
         )
 
         expected_email = {
             "subject": "[BETA] Small Business Lending Data Filing Confirmation",
-            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on March 15, 2024 at 10:10 a.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
+            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on March 15, 2024 at 6:10 a.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
             "from_addr": "test@cfpb.gov",
             "to": ["test@cfpb.gov"],
             "cc": None,
@@ -152,14 +155,17 @@ class TestEmailApiSend:
                     "signer_email": "test@cfpb.gov",
                     "signer_name": "Test User",
                     "contact_email": "test_contact@cfpb.gov",
-                    "timestamp": datetime(2024, 9, 15, 13, 10).timestamp() * 1000,
+                    "timestamp": datetime(
+                        2024, 9, 15, 17, 10, tzinfo=timezone.utc
+                    ).timestamp()
+                    * 1000,
                 }
             ),
         )
 
         expected_email = {
             "subject": "[BETA] Small Business Lending Data Filing Confirmation",
-            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on Sept. 15, 2024 at 3:10 p.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
+            "body": "\nCongratulations! This email confirms that the filing submitted by Test User on Sept. 15, 2024 at 1:10 p.m. EST was successful. The confirmation number is test.\n\nThe beta platform is for testing purposes only and user-supplied data may be removed at any time. Take a moment to email our support staff at sblhelp@cfpb.gov with your feedback or return to the beta platform and upload a new file to continue testing.\n",
             "from_addr": "test@cfpb.gov",
             "to": ["test@cfpb.gov"],
             "cc": None,


### PR DESCRIPTION
Closes #50 

Changes confirmation email to have beta and prod body text, as well as [BETA] in the subject only if not prod.

Changed the beta text based on suggestions.